### PR TITLE
Convert performance tests to use BenchmarkDotNet

### DIFF
--- a/FastMember_Net40.Signed.Tests/FastMember_Net40.Signed.Tests.csproj
+++ b/FastMember_Net40.Signed.Tests/FastMember_Net40.Signed.Tests.csproj
@@ -38,6 +38,10 @@
     <AssemblyOriginatorKeyFile>../FastMember.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="BenchmarkDotNet, Version=0.9.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\BenchmarkDotNet.0.9.1\lib\net40\BenchmarkDotNet.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="nunit.framework, Version=3.0.5797.27534, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.3.0.0\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>

--- a/FastMember_Net40.Signed.Tests/packages.config
+++ b/FastMember_Net40.Signed.Tests/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="BenchmarkDotNet" version="0.9.1" targetFramework="net45" />
   <package id="NUnit" version="3.0.0" targetFramework="net45" />
 </packages>

--- a/FastMember_Net40.Tests/FastMember_Net40.Tests.csproj
+++ b/FastMember_Net40.Tests/FastMember_Net40.Tests.csproj
@@ -34,6 +34,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="BenchmarkDotNet, Version=0.9.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\BenchmarkDotNet.0.9.1\lib\net40\BenchmarkDotNet.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="nunit.framework, Version=3.0.5797.27539, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.3.0.0\lib\net40\nunit.framework.dll</HintPath>

--- a/FastMember_Net40.Tests/packages.config
+++ b/FastMember_Net40.Tests/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="3.0.0" targetFramework="net40" />
+  <package id="BenchmarkDotNet" version="0.9.1" targetFramework="net4" />
+  <package id="NUnit" version="3.0.0" targetFramework="net4" />
 </packages>

--- a/Nuget.config
+++ b/Nuget.config
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
I'll leave it up to you whether you want to accept this or not, but I just wanted to show you what it would look like if the performance tests were re-written to use [BenchmarkDotNet](https://github.com/PerfDotNet/BenchmarkDotNet) (full disclaimer, I'm one of the authors)

This is the output you get in the console

![fastmember performance tests with benchmarkdotnet](https://cloud.githubusercontent.com/assets/157298/13226701/bcf80ffe-d98a-11e5-8b70-d997bf5b1fe6.png)

Or in markdown friendly format:

```ini
BenchmarkDotNet-Dev=v0.9.1.0+
OS=Microsoft Windows NT 6.1.7601 Service Pack 1
Processor=Intel(R) Core(TM) i7-4800MQ CPU @ 2.70GHz, ProcessorCount=8
Frequency=2630771 ticks, Resolution=380.1167 ns
HostCLR=MS.NET 4.0.30319.42000, Arch=32-bit RELEASE
JitModules=clrjit-v4.6.100.0
```
                      Method |      Median |     StdDev | Scaled |
---------------------------- |------------ |----------- |------- |
                1. Static C# |   9.4196 ns |  0.1269 ns |   1.00 |
               2. Dynamic C# |  52.0478 ns | 11.2937 ns |   5.53 |
             3. PropertyInfo | 531.5502 ns |  1.9314 ns |  56.43 |
       4. PropertyDescriptor | 935.3427 ns |  3.8777 ns |  99.30 |
      5. TypeAccessor.Create |  85.0064 ns |  2.4825 ns |   9.02 |
    6. ObjectAccessor.Create |  87.7486 ns |  0.1910 ns |   9.32 |
                 7. c# new() |  32.2484 ns |  0.1598 ns |   3.42 |
 8. Activator.CreateInstance |  66.5984 ns |  2.1463 ns |   7.07 |
   9. TypeAccessor.CreateNew |  35.3345 ns |  3.3308 ns |   3.75 |

For reference this [.zip file contains](https://github.com/mgravell/fast-member/files/141079/FastMember.and.BenchmarkDotNet.zip) all the files that are generated after a run (.csv, .log and markdown)