### PR TITLE
No NuGet dependency for .NET Core 2.0

### DIFF
--- a/FastMember.Signed/FastMember.Signed.csproj
+++ b/FastMember.Signed/FastMember.Signed.csproj
@@ -5,7 +5,7 @@
     <!--<AssemblyTitle>FastMember</AssemblyTitle>-->
     <Version>1.3.0</Version>
     <Authors>Marc Gravell</Authors>
-    <TargetFrameworks>net40;net45;netstandard1.5;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net40;net45;netstandard1.5;netstandard2.0;netcoreapp2.0</TargetFrameworks>
     <!--<RuntimeIdentifiers>win7-x64;win7-x86;osx.10.10-x64;osx.10.11-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64</RuntimeIdentifiers>-->
     <AssemblyName>FastMember</AssemblyName>
     <PackageTags>Reflection;Dynamic;Member;Access</PackageTags>
@@ -41,14 +41,18 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.5'">
-    <AddCoreFxLibs>true</AddCoreFxLibs>
+    <AddStandardFxLibs>true</AddStandardFxLibs>
     <DefineConstants>$(DefineConstants);COREFX;NO_SCHEMA_TABLE;NO_DB_ENUMERATOR</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <AddStandardFxLibs>true</AddStandardFxLibs>
+    <DefineConstants>$(DefineConstants);COREFX</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
     <AddCoreFxLibs>true</AddCoreFxLibs>
     <DefineConstants>$(DefineConstants);COREFX</DefineConstants>
   </PropertyGroup>
-  <ItemGroup Condition="'$(AddCoreFxLibs)' == 'true'">
+  <ItemGroup Condition="'$(AddStandardFxLibs)' == 'true'">
     <PackageReference Include="Microsoft.CSharp">
       <Version>4.3.0</Version>
     </PackageReference>

--- a/FastMember/FastMember.csproj
+++ b/FastMember/FastMember.csproj
@@ -13,7 +13,7 @@
     <AssemblyTitle>FastMember</AssemblyTitle>
     <Version>1.3.0</Version>
     <Authors>Marc Gravell</Authors>
-    <TargetFrameworks>net40;net45;netstandard1.5;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net40;net45;netstandard1.5;netstandard2.0;netcoreapp2.0</TargetFrameworks>
     <AssemblyName>FastMember</AssemblyName>
     <PackageTags>Reflection;Dynamic;Member;Access</PackageTags>
     <PackageReleaseNotes>core-clr support (rtm)</PackageReleaseNotes>
@@ -37,14 +37,18 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.5'">
-    <AddCoreFxLibs>true</AddCoreFxLibs>
+    <AddStandardFxLibs>true</AddStandardFxLibs>
     <DefineConstants>$(DefineConstants);COREFX;NO_SCHEMA_TABLE;NO_DB_ENUMERATOR</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <AddStandardFxLibs>true</AddStandardFxLibs>
+    <DefineConstants>$(DefineConstants);COREFX</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
     <AddCoreFxLibs>true</AddCoreFxLibs>
     <DefineConstants>$(DefineConstants);COREFX</DefineConstants>
   </PropertyGroup>
-  <ItemGroup Condition="'$(AddCoreFxLibs)' == 'true'">
+  <ItemGroup Condition="'$(AddStandardFxLibs)' == 'true'">
     <PackageReference Include="Microsoft.CSharp">
       <Version>4.3.0</Version>
     </PackageReference>


### PR DESCRIPTION
.Net Core 2.0 doesn't need any nuget package. So there are unnecessary dependings on the nuget package.