### PR TITLE
Fix for Issue #35.

### DIFF
--- a/FastMember.Signed.Tests/FastMember.Signed.Tests.csproj
+++ b/FastMember.Signed.Tests/FastMember.Signed.Tests.csproj
@@ -8,8 +8,6 @@
     <AssemblyOriginatorKeyFile>../FastMember.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
-    
-    <xUnitVersion>2.4.0</xUnitVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="**\*.cs" Exclude="Properties;project.*.json;bin\**;obj\**;**\*.xproj;packages\**" />
@@ -21,9 +19,9 @@
     <ProjectReference Include="..\FastMember.Signed\FastMember.Signed.csproj" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="xunit" Version="$(xUnitVersion)" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="$(xUnitVersion)" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="$(xUnitVersion)" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.4.0" />
 
     <PackageReference Include="BenchmarkDotNet" Version="0.10.14" />
     <PackageReference Include="System.Data.Common" Version="4.3.0" />

--- a/FastMember.Signed.Tests/FastMember.Signed.Tests.csproj
+++ b/FastMember.Signed.Tests/FastMember.Signed.Tests.csproj
@@ -9,7 +9,7 @@
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     
-    <xUnitVersion>2.4.0-beta.2.build3981</xUnitVersion>
+    <xUnitVersion>2.4.0</xUnitVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="**\*.cs" Exclude="Properties;project.*.json;bin\**;obj\**;**\*.xproj;packages\**" />
@@ -20,7 +20,7 @@
   <ItemGroup>
     <ProjectReference Include="..\FastMember.Signed\FastMember.Signed.csproj" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="xunit" Version="$(xUnitVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(xUnitVersion)" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="$(xUnitVersion)" />

--- a/FastMember.Signed.Tests/FastMember.Signed.Tests.csproj
+++ b/FastMember.Signed.Tests/FastMember.Signed.Tests.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.4.0" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.4.0-beta.2.build4005" />
 
     <PackageReference Include="BenchmarkDotNet" Version="0.10.14" />
     <PackageReference Include="System.Data.Common" Version="4.3.0" />

--- a/FastMember.Signed/FastMember.Signed.csproj
+++ b/FastMember.Signed/FastMember.Signed.csproj
@@ -23,9 +23,6 @@
     <EmbeddedResource Include="**\*.resx" />
     <EmbeddedResource Include="compiler\resources\**\*" />
   </ItemGroup>
-  <ItemGroup>
-    <Compile Remove="..\FastMember\TypeHelpers.cs" />
-  </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='net461'">
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>

--- a/FastMember.Tests/BasicTests.cs
+++ b/FastMember.Tests/BasicTests.cs
@@ -1,5 +1,6 @@
 ﻿using FastMember;
 using System;
+using System.Collections.Generic;
 using System.Data;
 using System.Linq;
 using Xunit;
@@ -242,6 +243,42 @@ namespace FastMemberTests
             public decimal? D;
         }
 
+        public interface IPropsOnInterfaceBase
+        {
+            int A { get; set; }
+            string B { get; set; }
+            DateTime? C { get; set; }
+            decimal? D { get; set; }
+        }
+        public interface IPropsOnInterfaceBase2
+        {
+            int E { get; set; }
+            string F { get; set; }
+            DateTime? G { get; set; }
+            decimal? H { get; set; }
+        }
+        public interface IPropsOnInheritedInterface : IPropsOnInterfaceBase
+        {
+            int I { get; set; }
+            string J { get; set; }
+            DateTime? K { get; set; }
+            decimal? L { get; set; }
+        }
+        public interface IPropseOnComposedInterface : IPropsOnInterfaceBase, IPropsOnInterfaceBase2
+        {
+            int M { get; set; }
+            string N { get; set; }
+            DateTime? O { get; set; }
+            decimal? P { get; set; }
+        }
+        public interface IPropseOnInheritedComposedInterface : IPropsOnInheritedInterface, IPropsOnInterfaceBase2
+        {
+            int M { get; set; }
+            string N { get; set; }
+            DateTime? O { get; set; }
+            decimal? P { get; set; }
+        }
+
 
         public class HasDefaultCtor { }
         public class HasNoDefaultCtor { public HasNoDefaultCtor(string s) { } }
@@ -437,5 +474,82 @@ namespace FastMemberTests
             var memberNames = string.Join(",", acc.GetMembers().Select(x => x.Name).OrderBy(_ => _));
             Assert.Equal("Foo,Foo2", memberNames);
         }
+
+        [Fact]
+        public void TestGetMembersOnInterface()
+        {
+            var access = TypeAccessor.Create(typeof(IPropsOnInterfaceBase));
+            Assert.True(access.GetMembersSupported);
+            var members = access.GetMembers();
+            Assert.Equal(4, members.Count);
+            Assert.Equal("A", members[0].Name);
+            Assert.Equal("B", members[1].Name);
+            Assert.Equal("C", members[2].Name);
+            Assert.Equal("D", members[3].Name);
+        }
+
+        [Fact]
+        public void TestGetMembersOnInheritedInterface()
+        {
+            var access = TypeAccessor.Create(typeof(IPropsOnInheritedInterface));
+            Assert.True(access.GetMembersSupported);
+            var members = access.GetMembers();
+            Assert.Equal(8, members.Count);
+            Assert.Equal("A", members[0].Name);
+            Assert.Equal("B", members[1].Name);
+            Assert.Equal("C", members[2].Name);
+            Assert.Equal("D", members[3].Name);
+            Assert.Equal("I", members[4].Name);
+            Assert.Equal("J", members[5].Name);
+            Assert.Equal("K", members[6].Name);
+            Assert.Equal("L", members[7].Name);
+        }
+
+        [Fact]
+        public void TestGetMembersOnComposedInterface()
+        {
+            var access = TypeAccessor.Create(typeof(IPropseOnComposedInterface));
+            Assert.True(access.GetMembersSupported);
+            var members = access.GetMembers();
+            Assert.Equal(12, members.Count);
+            Assert.Equal("A", members[0].Name);
+            Assert.Equal("B", members[1].Name);
+            Assert.Equal("C", members[2].Name);
+            Assert.Equal("D", members[3].Name);
+            Assert.Equal("E", members[4].Name);
+            Assert.Equal("F", members[5].Name);
+            Assert.Equal("G", members[6].Name);
+            Assert.Equal("H", members[7].Name);
+            Assert.Equal("M", members[8].Name);
+            Assert.Equal("N", members[9].Name);
+            Assert.Equal("O", members[10].Name);
+            Assert.Equal("P", members[11].Name);
+        }
+
+        [Fact]
+        public void TestGetMembersOnInheritedComposedInterface()
+        {
+            var access = TypeAccessor.Create(typeof(IPropseOnInheritedComposedInterface));
+            Assert.True(access.GetMembersSupported);
+            var members = access.GetMembers();
+            Assert.Equal(16, members.Count);
+            Assert.Equal("A", members[0].Name);
+            Assert.Equal("B", members[1].Name);
+            Assert.Equal("C", members[2].Name);
+            Assert.Equal("D", members[3].Name);
+            Assert.Equal("E", members[4].Name);
+            Assert.Equal("F", members[5].Name);
+            Assert.Equal("G", members[6].Name);
+            Assert.Equal("H", members[7].Name);
+            Assert.Equal("I", members[8].Name);
+            Assert.Equal("J", members[9].Name);
+            Assert.Equal("K", members[10].Name);
+            Assert.Equal("L", members[11].Name);
+            Assert.Equal("M", members[12].Name);
+            Assert.Equal("N", members[13].Name);
+            Assert.Equal("O", members[14].Name);
+            Assert.Equal("P", members[15].Name);
+        }
+
     }
 }

--- a/FastMember.Tests/FastMember.Tests.csproj
+++ b/FastMember.Tests/FastMember.Tests.csproj
@@ -5,7 +5,6 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>FastMember.Tests</AssemblyName>
     <OutputType>Exe</OutputType>
-    <xUnitVersion>2.4.0</xUnitVersion>
   </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Include="**\*.resx" />
@@ -16,9 +15,9 @@
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
     <PackageReference Include="BenchmarkDotNet" Version="0.10.14" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="xunit" Version="$(xUnitVersion)" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="$(xUnitVersion)" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="$(xUnitVersion)" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.4.0" />
     <PackageReference Include="System.Data.Common" Version="4.3.0" />
   </ItemGroup>
   <PropertyGroup Label="Configuration">

--- a/FastMember.Tests/FastMember.Tests.csproj
+++ b/FastMember.Tests/FastMember.Tests.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.4.0" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.4.0-beta.2.build4005" />
     <PackageReference Include="System.Data.Common" Version="4.3.0" />
   </ItemGroup>
   <PropertyGroup Label="Configuration">

--- a/FastMember.Tests/FastMember.Tests.csproj
+++ b/FastMember.Tests/FastMember.Tests.csproj
@@ -5,7 +5,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>FastMember.Tests</AssemblyName>
     <OutputType>Exe</OutputType>
-    <xUnitVersion>2.4.0-beta.2.build3981</xUnitVersion>
+    <xUnitVersion>2.4.0</xUnitVersion>
   </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Include="**\*.resx" />
@@ -15,7 +15,7 @@
     <ProjectReference Include="..\FastMember\FastMember.csproj" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
     <PackageReference Include="BenchmarkDotNet" Version="0.10.14" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="xunit" Version="$(xUnitVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(xUnitVersion)" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="$(xUnitVersion)" />

--- a/FastMember/MemberSet.cs
+++ b/FastMember/MemberSet.cs
@@ -14,7 +14,7 @@ namespace FastMember
         internal MemberSet(Type type)
         {
             const BindingFlags PublicInstance = BindingFlags.Public | BindingFlags.Instance;
-            members = type.GetProperties(PublicInstance).Cast<MemberInfo>().Concat(type.GetFields(PublicInstance).Cast<MemberInfo>()).OrderBy(x => x.Name)
+            members = type.GetTypeAndInterfaceProperties(PublicInstance).Cast<MemberInfo>().Concat(type.GetFields(PublicInstance).Cast<MemberInfo>()).OrderBy(x => x.Name)
                 .Select(member => new Member(member)).ToArray();
         }
         /// <summary>

--- a/FastMember/TypeAccessor.cs
+++ b/FastMember/TypeAccessor.cs
@@ -262,7 +262,7 @@ namespace FastMember
                 return DynamicAccessor.Singleton;
             }
 
-            PropertyInfo[] props = type.GetProperties(BindingFlags.Public | BindingFlags.Instance);
+            PropertyInfo[] props = type.GetTypeAndInterfaceProperties(BindingFlags.Public | BindingFlags.Instance);
             FieldInfo[] fields = type.GetFields(BindingFlags.Public | BindingFlags.Instance);
             Dictionary<string, int> map = new Dictionary<string, int>();
             List<MemberInfo> members = new List<MemberInfo>(props.Length + fields.Length);

--- a/FastMember/TypeHelpers.cs
+++ b/FastMember/TypeHelpers.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
 
@@ -12,5 +13,18 @@ namespace FastMember
         {
             return x < y ? x : y;
         }
+
+        /// <summary>
+        /// If type is a class, get its properties; if type is an interface, get its
+        /// properties plus the properties of all the interfaces it inherits.
+        /// </summary>
+        /// <param name="type"></param>
+        /// <param name="flags"></param>
+        /// <returns></returns>
+        public static PropertyInfo[] GetTypeAndInterfaceProperties(this Type type, BindingFlags flags)
+        {
+            return !type.IsInterface ? type.GetProperties(flags) : (new[] { type }).Concat(type.GetInterfaces()).SelectMany(i => i.GetProperties(flags)).ToArray();
+        }
+
     }
 }

--- a/Nuget.config
+++ b/Nuget.config
@@ -2,6 +2,6 @@
 <configuration>
   <packageSources>
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key"myget.org" value="https://www.myget.org/F/xunit/api/v3/index.json " />
+    <add key="myget.org" value="https://www.myget.org/F/xunit/api/v3/index.json " />
   </packageSources>
 </configuration>

--- a/Nuget.config
+++ b/Nuget.config
@@ -2,5 +2,6 @@
 <configuration>
   <packageSources>
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key"myget.org" value="https://www.myget.org/F/xunit/api/v3/index.json " />
   </packageSources>
 </configuration>


### PR DESCRIPTION
Fix for Issue #35, to add support for creating a TypeAccessor on an interface with full support for interface inheritance and composition. Added test cases to support the code change.

Also updated xUnit to v2.4.0 and updated .NET Test SDK to 15.8.0. Using latest beta of dotnet-xunit from myget.org.