### PR TITLE
Extend meaning/value of allowNonPublicAccessors

### DIFF
--- a/FastMember.Signed.Tests/FastMember.Signed.Tests.csproj
+++ b/FastMember.Signed.Tests/FastMember.Signed.Tests.csproj
@@ -8,8 +8,6 @@
     <AssemblyOriginatorKeyFile>../FastMember.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
-    
-    <xUnitVersion>2.4.0-beta.2.build3981</xUnitVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="**\*.cs" Exclude="Properties;project.*.json;bin\**;obj\**;**\*.xproj;packages\**" />
@@ -20,12 +18,13 @@
   <ItemGroup>
     <ProjectReference Include="..\FastMember.Signed\FastMember.Signed.csproj" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
-    <PackageReference Include="xunit" Version="$(xUnitVersion)" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="$(xUnitVersion)" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="$(xUnitVersion)" />
-
-    <PackageReference Include="BenchmarkDotNet" Version="0.10.14" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="BenchmarkDotNet" Version="0.11.4" />
     <PackageReference Include="System.Data.Common" Version="4.3.0" />
   </ItemGroup>
   <PropertyGroup Label="Configuration">

--- a/FastMember.Tests/BasicTests.cs
+++ b/FastMember.Tests/BasicTests.cs
@@ -437,5 +437,33 @@ namespace FastMemberTests
             var memberNames = string.Join(",", acc.GetMembers().Select(x => x.Name).OrderBy(_ => _));
             Assert.Equal("Foo,Foo2", memberNames);
         }
+
+        public class HazNonPublicPropAndField
+        {
+            private int Foo { get; set; }
+            private int Bar;
+        }
+
+        [Fact]
+        public void BasicReadTest_NonPublicAccessorMembers()
+        {
+            var acc = TypeAccessor.Create(typeof(HazNonPublicPropAndField), allowNonPublicAccessors: true);
+            var memberNames = string.Join(",", acc.GetMembers().Select(x => x.Name).OrderBy(_ => _));
+            Assert.Equal("Bar,Foo", memberNames);
+        }
+
+        [Fact]
+        public void BasicWriteTest_NonPublicAccessorMembers()
+        {
+            var obj = new HazNonPublicPropAndField();
+
+            var access = TypeAccessor.Create(typeof(HazNonPublicPropAndField), allowNonPublicAccessors: true);
+
+            access[obj, "Foo"] = 123;
+            access[obj, "Bar"] = 321;
+
+            Assert.Equal(123, access[obj, "Foo"]);
+            Assert.Equal(321, access[obj, "Bar"]);
+        }
     }
 }

--- a/FastMember.Tests/FastMember.Tests.csproj
+++ b/FastMember.Tests/FastMember.Tests.csproj
@@ -5,7 +5,6 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>FastMember.Tests</AssemblyName>
     <OutputType>Exe</OutputType>
-    <xUnitVersion>2.4.0-beta.2.build3981</xUnitVersion>
   </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Include="**\*.resx" />
@@ -14,11 +13,13 @@
   <ItemGroup>
     <ProjectReference Include="..\FastMember\FastMember.csproj" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-    <PackageReference Include="BenchmarkDotNet" Version="0.10.14" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
-    <PackageReference Include="xunit" Version="$(xUnitVersion)" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="$(xUnitVersion)" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="$(xUnitVersion)" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.11.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="System.Data.Common" Version="4.3.0" />
   </ItemGroup>
   <PropertyGroup Label="Configuration">

--- a/FastMember.Tests/Program.cs
+++ b/FastMember.Tests/Program.cs
@@ -35,9 +35,9 @@ namespace FastMemberTests
                 var summary = BenchmarkRunner.Run<FastMemberPerformance>(new Config());
                 Console.WriteLine();
 				// Display a summary to match the output of the original Performance test
-				foreach (var report in summary.Reports.OrderBy(r => r.Benchmark.Target.MethodDisplayInfo))
+				foreach (var report in summary.Reports.OrderBy(r => r.BenchmarkCase.DisplayInfo))
 				{
-					Console.WriteLine("{0}: {1:N2} ns", report.Benchmark.Target.MethodDisplayInfo, report.ResultStatistics.Median);
+					Console.WriteLine("{0}: {1:N2} ns", report.BenchmarkCase.DisplayInfo, report.ResultStatistics.Median);
 				}
 				Console.WriteLine();
             }

--- a/FastMember/MemberSet.cs
+++ b/FastMember/MemberSet.cs
@@ -11,11 +11,9 @@ namespace FastMember
     public sealed class MemberSet : IEnumerable<Member>, IList<Member>
     {
         Member[] members;
-        internal MemberSet(Type type)
+        internal MemberSet(MemberInfo[] members)
         {
-            const BindingFlags PublicInstance = BindingFlags.Public | BindingFlags.Instance;
-            members = type.GetProperties(PublicInstance).Cast<MemberInfo>().Concat(type.GetFields(PublicInstance).Cast<MemberInfo>()).OrderBy(x => x.Name)
-                .Select(member => new Member(member)).ToArray();
+            this.members = members.OrderBy(x => x.Name).Select(member => new Member(member)).ToArray();
         }
         /// <summary>
         /// Return a sequence of all defined members


### PR DESCRIPTION
The original concept of `allowNonPublicAccessors` only considers the accessor's root type access, and not its members' access. However, `IsFullyPublic`, the method that determines whether the accessor needs to be delegated, considers members.

This means that if you have a public type you want to access, its non-public members are not accessible, even if you explicitly ask for them via `allowNonPublicAccessors: true`. This is demonstrated in the accompanying unit tests. Now, maybe the field really means that (accessors, not members), but it seems in spirit with what the library is meant to provide, that it would not hide private members. In fact, all of my use cases over the last five years involve wanting to manipulate private members in a non-public accessor. 

As a side benefit, in order to avoid calling reflection for properties and fields twice, once when spinning up an accessor, and again when asking for a member set for the first time, we cache the `MemberInfo[]` collection after doing a safe-ish filter on backing fields. This is a common request: to make reflection info available so that consumers don't have to pay the tax on accessor creation, and then again in their own app for other introspection tasks: just use the cached member info on the accessor itself. This helps library authors centralize "stuff for type access".