### PR TITLE
Added support for fields to CanRead, CanWrite

### DIFF
--- a/FastMember.Tests/BasicTests.cs
+++ b/FastMember.Tests/BasicTests.cs
@@ -185,6 +185,22 @@ namespace FastMemberTests
         }
 
         [Fact]
+        public void CanReadTest_FieldsOnClass()
+        {
+            var access = TypeAccessor.Create(typeof(FieldsOnClass));
+
+            Assert.True(access.GetMembers().First().CanRead);
+        }
+
+        [Fact]
+        public void CanWriteTest_FieldsOnClass()
+        {
+            var access = TypeAccessor.Create(typeof(FieldsOnClass));
+
+            Assert.True(access.GetMembers().First().CanWrite);
+        }
+
+        [Fact]
         public void WriteInvalidMember()
         {
             Assert.Throws<ArgumentOutOfRangeException>(() =>

--- a/FastMember/MemberSet.cs
+++ b/FastMember/MemberSet.cs
@@ -124,6 +124,7 @@ namespace FastMember
             {
                 switch (member.MemberType)
                 {
+                    case MemberTypes.Field: return true;
                     case MemberTypes.Property: return ((PropertyInfo)member).CanWrite;
                     default: throw new NotSupportedException(member.MemberType.ToString());
                 }
@@ -139,6 +140,7 @@ namespace FastMember
             {
                 switch (member.MemberType)
                 {
+                    case MemberTypes.Field: return true;
                     case MemberTypes.Property: return ((PropertyInfo)member).CanRead;
                     default: throw new NotSupportedException(member.MemberType.ToString());
                 }


### PR DESCRIPTION
@mgravell 

Please consider this modification to CanRead, CanWrite. The methods are not safe on results of GetMembers().