### PR TITLE
A small change that makes it possible to pass ObjectReader as SqlDbType.Structured parameter to a stored procedure call

### DIFF
--- a/FastMember/ObjectReader.cs
+++ b/FastMember/ObjectReader.cs
@@ -38,7 +38,7 @@ namespace FastMember
         /// <param name="members">The members that should be exposed to the reader</param>
         public static ObjectReader Create<T>(IEnumerable<T> source, params string[] members)
         {
-            return new ObjectReader(typeof(T), source, members: members);
+            return new ObjectReader(typeof(T), source, members);
         }
 
         /// <summary>
@@ -48,11 +48,21 @@ namespace FastMember
         /// <param name="source">The sequence of objects to represent</param>
         /// <param name="keyPropertyName">Current object property name to set IsKey column value for schema table</param>
         /// <param name="members">The members that should be exposed to the reader</param>
-        public ObjectReader(Type type, IEnumerable source, string keyPropertyName = "", params string[] members)
+        public ObjectReader(Type type, IEnumerable source, string keyPropertyName = "", params string[] members) :
+            this(type, source, members)
+        {
+            this.keyPropertyName = keyPropertyName;
+        }
+
+        /// <summary>
+        /// Creates a new ObjectReader instance for reading the supplied data
+        /// </summary>
+        /// <param name="type">The expected Type of the information to be read</param>
+        /// <param name="source">The sequence of objects to represent</param>
+        /// <param name="members">The members that should be exposed to the reader</param>
+        public ObjectReader(Type type, IEnumerable source, params string[] members)
         {
             if (source == null) throw new ArgumentOutOfRangeException(nameof(source));
-            
-            this.keyPropertyName = keyPropertyName;
 
             bool allMembers = members == null || members.Length == 0;
 

--- a/FastMember/ObjectReader.cs
+++ b/FastMember/ObjectReader.cs
@@ -26,7 +26,7 @@ namespace FastMember
         /// Creates a new ObjectReader instance for reading the supplied data
         /// </summary>
         /// <param name="source">The sequence of objects to represent</param>
-        /// <param name="keyPropertyName">Current object property name to set IsKey column value for schema table</param>
+        /// <param name="keyPropertyExpression">Current object property expression to set IsKey column value for schema table</param>
         /// <param name="members">The members that should be exposed to the reader</param>
         public static ObjectReader Create<TSource, TProperty>(IEnumerable<TSource> source, Expression<Func<TSource, TProperty>> keyPropertyExpression, params string[] members)
         {
@@ -55,7 +55,7 @@ namespace FastMember
         /// </summary>
         /// <param name="type">The expected Type of the information to be read</param>
         /// <param name="source">The sequence of objects to represent</param>
-        /// <param name="keyPropertyName">Current object property name to set IsKey column value for schema table</param>
+        /// <param name="keyPropertyMemberInfo">Current object property info to set IsKey column value for schema table</param>
         /// <param name="members">The members that should be exposed to the reader</param>
         public ObjectReader(Type type, IEnumerable source, MemberInfo keyPropertyMemberInfo, params string[] members) :
             this(type, source, members)


### PR DESCRIPTION
A small change that makes it possible to pass ObjectReader as SqlDbType.Structured parameter to a stored procedure call.
This previously threw an NRF exception in the Microsoft.Data.SqlClient.GetActualFieldsAndProperties method when it tried to access a property on a non-existent column "IsKey".