### PR TITLE
#105 Add new TFM's

### DIFF
--- a/FastMember.Signed/FastMember.Signed.csproj
+++ b/FastMember.Signed/FastMember.Signed.csproj
@@ -4,7 +4,7 @@
     <Copyright>Copyright © Marc Gravell 2012-2016</Copyright>
     <Version>1.5.0</Version>
     <Authors>Marc Gravell</Authors>
-    <TargetFrameworks>netstandard2.0;net461;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461;netcoreapp2.0;netstandard2.1;netcoreapp3.0</TargetFrameworks>
     <AssemblyName>FastMember</AssemblyName>
     <PackageTags>Reflection;Dynamic;Member;Access</PackageTags>
     <PackageReleaseNotes>core-clr support (rtm)</PackageReleaseNotes>
@@ -34,5 +34,8 @@
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageReference Include="System.Security.Permissions" Version="4.5.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.1'">
+    <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
   </ItemGroup>
 </Project>

--- a/FastMember/FastMember.csproj
+++ b/FastMember/FastMember.csproj
@@ -5,7 +5,7 @@
     <AssemblyTitle>FastMember</AssemblyTitle>
     <Version>1.5.0</Version>
     <Authors>Marc Gravell</Authors>
-    <TargetFrameworks>netstandard2.0;net461;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461;netcoreapp2.0;netstandard2.1;netcoreapp3.0</TargetFrameworks>
     <AssemblyName>FastMember</AssemblyName>
     <PackageTags>Reflection;Dynamic;Member;Access</PackageTags>
     <PackageReleaseNotes>core-clr support (rtm)</PackageReleaseNotes>
@@ -29,5 +29,8 @@
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageReference Include="System.Security.Permissions" Version="4.5.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.1'">
+    <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Adds in net standard 2.1 and also net core 3.0. By adding these TFM's the dependency tree can be reduced

closes #105 